### PR TITLE
fix: minimum python version = 3.7

### DIFF
--- a/qualitair/pyproject.toml
+++ b/qualitair/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Benj Fassbind <randombenj@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.7,<4.0"
 pimoroni-sgp30 = "^0.0.2"
 aiohttp = "^3.7.3"
 smbus2 = "^0.4.1"


### PR DESCRIPTION
Change the minimum python version to 3.7. This is the default that is currently installed on the raspberry pi OS.